### PR TITLE
Generic xreceive

### DIFF
--- a/contracts/shared/ForwarderXReceiver.sol
+++ b/contracts/shared/ForwarderXReceiver.sol
@@ -5,10 +5,9 @@ import {IConnext} from "@connext/interfaces/core/IConnext.sol";
 import {IXReceiver} from "@connext/interfaces/core/IXReceiver.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-abstract contract XReceiver {
+abstract contract ForwarderXReceiver {
     // The Connext contract on this domain
     IConnext public immutable connext;
-    address public immutable target;
 
     /// Modifier
     modifier onlyConnext() {
@@ -24,44 +23,25 @@ abstract contract XReceiver {
         bytes32 _transferId,
         uint256 _amount, // Final Amount receive via Connext(After AMM calculation)
         address _asset,
-        address _originSender,
-        uint32 _origin,
+        address /*_originSender*/,
+        uint32 /*_origin*/,
         bytes calldata _callData
-    ) external payable onlyConnext returns (bool) {
+    ) external payable onlyConnext {
         // Decode calldata
-        (address fallbackAddress, bytes4 selector, bytes memory data) = abi
-            .decode(_callData, (address, bytes4, bytes));
+        (address fallbackAddress, bytes memory data) = abi
+            .decode(_callData, (address, bytes));
 
         require(fallbackAddress != address(0), "!invalidFallback");
 
-        bool success;
-        try forwardFunctionCall(data, _amount, _asset) returns (bool result) {
-            success = result;
-        // TODO: emit catch events
-        } catch Error(string memory /*reason*/) {
-            // This is executed in case
-            // revert was called inside getData
-            // and a reason string was provided.
-            success = false;
-        } catch Panic(uint /*errorCode*/) {
-            // This is executed in case of a panic,
-            // i.e. a serious error like division by zero
-            // or overflow. The error code can be used
-            // to determine the kind of error.
-            success = false;
-        } catch (bytes memory /*lowLevelData*/) {
-            // This is executed in case revert() was used.
-            success = false;
-        }
-
         // transfer to fallback address if forwardFunctionCall fails
-        if (!success) {
+        if (!forwardFunctionCall(_transferId, data, _amount, _asset)) {
             IERC20(_asset).transferFrom(msg.sender, fallbackAddress, _amount);
         }
     }
 
     /// INTERNAL
     function forwardFunctionCall(
+        bytes32 _transferId,
         bytes memory _data,
         uint256 _amount,
         address _asset

--- a/contracts/shared/ForwarderXReceiver.sol
+++ b/contracts/shared/ForwarderXReceiver.sol
@@ -35,7 +35,7 @@ abstract contract ForwarderXReceiver {
 
         // transfer to fallback address if forwardFunctionCall fails
         if (!forwardFunctionCall(_transferId, data, _amount, _asset)) {
-            IERC20(_asset).transferFrom(msg.sender, fallbackAddress, _amount);
+            IERC20(_asset).transfer(fallbackAddress, _amount);
         }
     }
 

--- a/contracts/shared/UniswapV3Swapper.sol
+++ b/contracts/shared/UniswapV3Swapper.sol
@@ -1,0 +1,50 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.8.7 <0.9.0;
+
+import "@openzeppelin/contracts/utils/Address.sol";
+import {ISwapRouter} from "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
+
+import {ProtocolTarget} from "./ProtocolTarget.sol";
+
+contract Swapper is ProtocolTarget {
+    ISwapRouter public immutable UniswapSwapRouter =
+        ISwapRouter(0xE592427A0AEce92De3Edee1F18E0157C05861564);
+
+    constructor(address _connext) XReceiver(_connext) {}
+
+    function forwardFunctionCall(
+        bytes memory _data,
+        uint256 _amount,
+        address _asset
+    ) internal virtual returns (bool) {
+        (
+            address fromAsset,
+            address toAsset,
+            uint24 poolFee,
+            uint256 amountOutMin,
+            address recipient
+        ) = abi.decode(
+                _data,
+                (address, address, uint24, uint256, address)
+            );
+
+        TransferHelper.safeApprove(fromAsset, address(UniswapSwapRouter), _amount);
+        // Set up uniswap swap params.
+        ISwapRouter.ExactInputSingleParams memory params = ISwapRouter
+            .ExactInputSingleParams({
+                tokenIn: fromAsset,
+                tokenOut: toAsset,
+                fee: poolFee,
+                recipient: recipient,
+                deadline: block.timestamp,
+                amountIn: _amount,
+                amountOutMinimum: amountOutMin,
+                sqrtPriceLimitX96: 0
+            });
+
+        // The call to `exactInputSingle` executes the swap.
+        ISwapRouter(swapper).exactInputSingle{value: value}(params);
+
+        return true;
+    }
+}

--- a/contracts/shared/XReceiver.sol
+++ b/contracts/shared/XReceiver.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {IConnext} from "@connext/interfaces/core/IConnext.sol";
+import {IXReceiver} from "@connext/interfaces/core/IXReceiver.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+abstract contract XReceiver {
+    // The Connext contract on this domain
+    IConnext public immutable connext;
+    address public immutable target;
+
+    /// Modifier
+    modifier onlyConnext() {
+        require(msg.sender == address(connext), "Caller must be Connext");
+        _;
+    }
+
+    constructor(address _connext) {
+        connext = IConnext(_connext);
+    }
+
+    function xReceive(
+        bytes32 _transferId,
+        uint256 _amount, // Final Amount receive via Connext(After AMM calculation)
+        address _asset,
+        address _originSender,
+        uint32 _origin,
+        bytes calldata _callData
+    ) external payable onlyConnext returns (bool) {
+        // Decode calldata
+        (address fallbackAddress, bytes4 selector, bytes memory data) = abi
+            .decode(_callData, (address, bytes4, bytes));
+
+        require(fallbackAddress != address(0), "!invalidFallback");
+
+        bool success;
+        try forwardFunctionCall(data, _amount, _asset) returns (bool result) {
+            success = result;
+        // TODO: emit catch events
+        } catch Error(string memory /*reason*/) {
+            // This is executed in case
+            // revert was called inside getData
+            // and a reason string was provided.
+            success = false;
+        } catch Panic(uint /*errorCode*/) {
+            // This is executed in case of a panic,
+            // i.e. a serious error like division by zero
+            // or overflow. The error code can be used
+            // to determine the kind of error.
+            success = false;
+        } catch (bytes memory /*lowLevelData*/) {
+            // This is executed in case revert() was used.
+            success = false;
+        }
+
+        if (!success) {
+            IERC20(_asset).transferFrom(msg.sender, fallbackAddress, _amount);
+        }
+    }
+
+    /// INTERNAL
+    function forwardFunctionCall(
+        bytes memory _data,
+        uint256 _amount,
+        address _asset
+    ) internal virtual returns (bool) {}
+}

--- a/contracts/shared/XReceiver.sol
+++ b/contracts/shared/XReceiver.sol
@@ -54,6 +54,7 @@ abstract contract XReceiver {
             success = false;
         }
 
+        // transfer to fallback address if forwardFunctionCall fails
         if (!success) {
             IERC20(_asset).transferFrom(msg.sender, fallbackAddress, _amount);
         }


### PR DESCRIPTION
I made a version of the template that's inheritable. Now integrators literally just need to inherit the XReceiver contract and implement the `forwardFunctionCall` which decodes the data and calls any external function. I provided an example for the Uniswap stuff.